### PR TITLE
단어장 화면, 단어 목록, 플래시 카드, 유의어 맞추기 [김민]

### DIFF
--- a/mobidic_flutter/lib/MainPage.dart
+++ b/mobidic_flutter/lib/MainPage.dart
@@ -1,0 +1,296 @@
+import 'package:flutter/material.dart';
+
+import 'list.dart';
+
+void main() {
+  runApp(MaterialApp(
+    home: VocabularyHomeScreen(),
+    debugShowCheckedModeBanner: false,
+    routes: {
+      '/wordlist': (context) => VocabularyScreen(),
+    },
+  ));
+}
+
+class VocabularyHomeScreen extends StatefulWidget {
+  const VocabularyHomeScreen({super.key});
+
+  @override
+  State<VocabularyHomeScreen> createState() => _VocabularyHomeScreenState();
+}
+
+class _VocabularyHomeScreenState extends State<VocabularyHomeScreen> {
+  int selectedCardIndex = -1;
+  List<String> vocabularyTitles = [];
+  List<bool> learnedStates = [];
+
+  void _navigateToWordList(String title) {
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => WordListScreen(title: title),
+      ),
+    );
+  }
+
+  // ✅ 이 함수는 고정된 라우트로 이동할 때 사용
+  void _navigateToWordListWithRoute() {
+    Navigator.pushNamed(context, '/wordlist');
+  }
+
+  void _showAddVocabularyDialog() {
+    TextEditingController controller = TextEditingController();
+    showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text('단어장 추가'),
+        content: TextField(
+          controller: controller,
+          decoration: InputDecoration(hintText: '새로운 단어장을 입력해 주세요'),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: Text('취소'),
+          ),
+          ElevatedButton(
+            onPressed: () {
+              if (controller.text.trim().isNotEmpty) {
+                setState(() {
+                  vocabularyTitles.add(controller.text.trim());
+                  learnedStates.add(false);
+                });
+                Navigator.pop(context);
+              }
+            },
+            child: Text('추가'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Container(
+        decoration: const BoxDecoration(
+          gradient: LinearGradient(
+            colors: [Color(0xFFb3e5fc), Color(0xFF81d4fa)],
+            begin: Alignment.topCenter,
+            end: Alignment.bottomCenter,
+          ),
+        ),
+        child: SafeArea(
+          child: Column(
+            children: [
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 12.0, vertical: 10.0),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Row(
+                      children: [
+                        Icon(Icons.arrow_back, size: 28),
+                        SizedBox(width: 8),
+                        Text('나만의 단어장',
+                            style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
+                      ],
+                    ),
+                    Icon(Icons.home, size: 28),
+                  ],
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 20.0, vertical: 8),
+                child: TextField(
+                  decoration: InputDecoration(
+                    hintText: '검색어를 입력해 주세요',
+                    prefixIcon: Icon(Icons.search),
+                    filled: true,
+                    fillColor: Colors.white,
+                    contentPadding: EdgeInsets.symmetric(vertical: 10),
+                    border: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(30),
+                      borderSide: BorderSide.none,
+                    ),
+                  ),
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 20),
+                child: ElevatedButton(
+                  onPressed: _showAddVocabularyDialog,
+                  child: Text('단어장 추가'),
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: Colors.white,
+                    foregroundColor: Colors.black87,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(20),
+                    ),
+                  ),
+                ),
+              ),
+              SizedBox(height: 10),
+              Expanded(
+                child: ListView.builder(
+                  padding: EdgeInsets.all(20),
+                  itemCount: vocabularyTitles.length,
+                  itemBuilder: (context, index) {
+                    return GestureDetector(
+                      onTap: _navigateToWordListWithRoute, // ✅ 배경 클릭 시 라우팅
+                      child: _buildVocabularyCard(index),
+                    );
+                  },
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildVocabularyCard(int index) {
+    bool isExpanded = selectedCardIndex == index;
+    return Container(
+      margin: const EdgeInsets.only(bottom: 20),
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: learnedStates[index] ? Colors.green[100] : Colors.yellow[100],
+        borderRadius: BorderRadius.circular(12),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black26,
+            blurRadius: 4,
+            offset: Offset(2, 2),
+          )
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(
+                vocabularyTitles[index],
+                style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+              ),
+              Row(
+                children: [
+                  Switch(
+                    value: learnedStates[index],
+                    onChanged: (val) {
+                      setState(() {
+                        learnedStates[index] = val;
+                      });
+                    },
+                  ),
+                  IconButton(
+                    icon: Icon(Icons.delete_outline),
+                    onPressed: () {},
+                  )
+                ],
+              )
+            ],
+          ),
+          Wrap(
+            spacing: 8,
+            runSpacing: 4,
+            children: [
+              ElevatedButton(
+                onPressed: () {
+                  setState(() {
+                    selectedCardIndex = isExpanded ? -1 : index;
+                  });
+                },
+                child: Text('퀴즈'),
+                style: _tagButtonStyle(),
+              ),
+              ElevatedButton(
+                onPressed: () {},
+                child: Text('발음 체크'),
+                style: _tagButtonStyle(),
+              ),
+              ElevatedButton(
+                onPressed: () {},
+                child: Text('파닉스'),
+                style: _tagButtonStyle(),
+              ),
+            ],
+          ),
+          if (isExpanded)
+            Container(
+              margin: const EdgeInsets.only(top: 12),
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: Colors.white,
+                borderRadius: BorderRadius.circular(12),
+                border: Border.all(color: Colors.blueAccent),
+                boxShadow: [
+                  BoxShadow(
+                    color: Colors.black12,
+                    blurRadius: 6,
+                    offset: Offset(0, 3),
+                  )
+                ],
+              ),
+              child: Wrap(
+                spacing: 10,
+                runSpacing: 10,
+                children: [
+                  ElevatedButton(
+                    onPressed: () => _navigateToWordList('플래시카드'),
+                    child: Text('플래시카드'),
+                  ),
+                  ElevatedButton(
+                    onPressed: () => _navigateToWordList('유의어 맞추기'),
+                    child: Text('유의어 맞추기'),
+                  ),
+                  ElevatedButton(
+                    onPressed: () => _navigateToWordList('받아쓰기'),
+                    child: Text('받아쓰기'),
+                  ),
+                  ElevatedButton(
+                    onPressed: () => _navigateToWordList('O/X 퀴즈'),
+                    child: Text('O/X 퀴즈'),
+                  ),
+                  ElevatedButton(
+                    onPressed: () => _navigateToWordList('빈칸 채우기'),
+                    child: Text('빈칸 채우기'),
+                  ),
+                ],
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  ButtonStyle _tagButtonStyle() {
+    return ElevatedButton.styleFrom(
+      backgroundColor: Colors.grey[300],
+      foregroundColor: Colors.black87,
+      shape: StadiumBorder(),
+    );
+  }
+}
+
+class WordListScreen extends StatelessWidget {
+  final String title;
+  const WordListScreen({required this.title});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('$title - 단어 목록'),
+        backgroundColor: Colors.blueAccent,
+      ),
+      body: Center(
+        child: Text('여기에 단어 목록이 표시됩니다.', style: TextStyle(fontSize: 18)),
+      ),
+    );
+  }
+}

--- a/mobidic_flutter/lib/flasgcard.dart
+++ b/mobidic_flutter/lib/flasgcard.dart
@@ -1,0 +1,192 @@
+
+import 'package:flutter/material.dart';
+
+void main() {
+  runApp(MaterialApp(
+    home: FlashcardScreen(),
+    debugShowCheckedModeBanner: false,
+  ));
+}
+
+class FlashcardScreen extends StatefulWidget {
+  const FlashcardScreen({super.key});
+
+  @override
+  State<FlashcardScreen> createState() => _FlashcardScreenState();
+}
+
+class _FlashcardScreenState extends State<FlashcardScreen> {
+  int currentIndex = 0;
+  bool showWord = true;
+  bool showMeaning = true;
+
+  final List<Map<String, String>> cards = [
+    {'word': 'apple', 'meaning': '사과'},
+    {'word': 'banana', 'meaning': '바나나'},
+    {'word': 'orange', 'meaning': '오렌지'},
+  ];
+
+  void _nextCard() {
+    setState(() {
+      currentIndex = (currentIndex + 1) % cards.length;
+      showWord = true;
+      showMeaning = true;
+    });
+  }
+
+  void _prevCard() {
+    setState(() {
+      currentIndex = (currentIndex - 1 + cards.length) % cards.length;
+      showWord = true;
+      showMeaning = true;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final card = cards[currentIndex];
+
+    return Scaffold(
+      body: Container(
+        width: double.infinity,
+        decoration: const BoxDecoration(
+          gradient: LinearGradient(
+            colors: [Color(0xFFb3e5fc), Color(0xFF81d4fa)],
+            begin: Alignment.topCenter,
+            end: Alignment.bottomCenter,
+          ),
+        ),
+        child: SafeArea(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              // 상단 바
+              Padding(
+                padding: const EdgeInsets.all(16.0),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: const [
+                    Icon(Icons.arrow_back, size: 28),
+                    Text(
+                      '플래시카드',
+                      style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+                    ),
+                    Icon(Icons.home, size: 28),
+                  ],
+                ),
+              ),
+              // 카드 내용
+              Expanded(
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 20.0),
+                  child: Container(
+                    padding: const EdgeInsets.all(20),
+                    decoration: BoxDecoration(
+                      color: Colors.white,
+                      borderRadius: BorderRadius.circular(20),
+                      boxShadow: [
+                        BoxShadow(
+                          color: Colors.black26,
+                          blurRadius: 6,
+                          offset: Offset(2, 4),
+                        ),
+                      ],
+                    ),
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        // 영단어 영역
+                        Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          children: [
+                            const Text('영단어', style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
+                            IconButton(
+                              icon: Icon(showWord ? Icons.visibility : Icons.visibility_off),
+                              onPressed: () {
+                                setState(() {
+                                  showWord = !showWord;
+                                });
+                              },
+                            )
+                          ],
+                        ),
+                        const SizedBox(height: 10),
+                        Stack(
+                          alignment: Alignment.center,
+                          children: [
+                            Text(
+                              card['word']!,
+                              style: const TextStyle(fontSize: 36, fontWeight: FontWeight.bold),
+                            ),
+                            if (!showWord)
+                              Positioned.fill(
+                                child: Container(
+                                  color: Colors.white,
+                                ),
+                              ),
+                          ],
+                        ),
+                        const Divider(height: 40, thickness: 1),
+                        // 뜻 영역
+                        Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          children: [
+                            const Text('뜻', style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
+                            IconButton(
+                              icon: Icon(showMeaning ? Icons.visibility : Icons.visibility_off),
+                              onPressed: () {
+                                setState(() {
+                                  showMeaning = !showMeaning;
+                                });
+                              },
+                            )
+                          ],
+                        ),
+                        const SizedBox(height: 10),
+                        Stack(
+                          alignment: Alignment.center,
+                          children: [
+                            Text(
+                              card['meaning']!,
+                              style: const TextStyle(fontSize: 28),
+                            ),
+                            if (!showMeaning)
+                              Positioned.fill(
+                                child: Container(
+                                  color: Colors.white,
+                                ),
+                              ),
+                          ],
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+              // 이전 / 다음 버튼
+              Padding(
+                padding: const EdgeInsets.only(bottom: 30.0),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    IconButton(
+                      icon: const Icon(Icons.arrow_back_ios),
+                      iconSize: 32,
+                      onPressed: _prevCard,
+                    ),
+                    const SizedBox(width: 40),
+                    IconButton(
+                      icon: const Icon(Icons.arrow_forward_ios),
+                      iconSize: 32,
+                      onPressed: _nextCard,
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/mobidic_flutter/lib/list.dart
+++ b/mobidic_flutter/lib/list.dart
@@ -1,0 +1,252 @@
+import 'package:flutter/material.dart';
+
+void main() {
+  runApp(MaterialApp(
+    home: VocabularyScreen(),
+    debugShowCheckedModeBanner: false,
+  ));
+}
+
+class VocabularyScreen extends StatefulWidget {
+  const VocabularyScreen({Key? key}) : super(key: key);
+
+  @override
+  State<VocabularyScreen> createState() => _VocabularyScreenState();
+}
+
+class _VocabularyScreenState extends State<VocabularyScreen> {
+  List<Map<String, dynamic>> wordList = [];
+
+  void _showAddWordDialog() {
+    TextEditingController wordController = TextEditingController();
+    TextEditingController meaningController = TextEditingController();
+
+    showDialog(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: Text('단어 추가'),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              TextField(
+                controller: wordController,
+                decoration: InputDecoration(hintText: '단어를 입력하세요'),
+              ),
+              SizedBox(height: 10),
+              TextField(
+                controller: meaningController,
+                decoration: InputDecoration(hintText: '뜻을 입력하세요'),
+              ),
+            ],
+          ),
+          actions: [
+            TextButton(
+              child: Text('취소'),
+              onPressed: () => Navigator.pop(context),
+            ),
+            ElevatedButton(
+              child: Text('추가'),
+              onPressed: () {
+                if (wordController.text.isNotEmpty &&
+                    meaningController.text.isNotEmpty) {
+                  setState(() {
+                    wordList.add({
+                      'word': wordController.text,
+                      'meaning': meaningController.text,
+                      'isLearned': false,
+                    });
+                  });
+                  Navigator.pop(context);
+                }
+              },
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  void _showDeleteDialog(int index) {
+    showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text('단어 삭제'),
+        content: Text('단어를 삭제하시겠습니까?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: Text('아니오'),
+          ),
+          TextButton(
+            onPressed: () {
+              setState(() {
+                wordList.removeAt(index);
+              });
+              Navigator.pop(context);
+            },
+            child: Text('예'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Container(
+        decoration: const BoxDecoration(
+          gradient: LinearGradient(
+            colors: [Color(0xFFb3e5fc), Color(0xFF81d4fa)],
+            begin: Alignment.topCenter,
+            end: Alignment.bottomCenter,
+          ),
+        ),
+        child: SafeArea(
+          child: Column(
+            children: [
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 12.0, vertical: 10.0),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Row(
+                      children: [
+                        IconButton(
+                          icon: const Icon(Icons.arrow_back, size: 28),
+                          onPressed: () {
+                            Navigator.pop(context);
+                          },
+                        ),
+                        const Text(
+                          '단어장 1',
+                          style: TextStyle(
+                            fontSize: 20,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                      ],
+                    ),
+                    IconButton(
+                      icon: const Icon(Icons.home, size: 28),
+                      onPressed: () {
+                        // 홈 이동 처리
+                      },
+                    ),
+                  ],
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 20.0, vertical: 10),
+                child: TextField(
+                  decoration: InputDecoration(
+                    hintText: '검색어를 입력해 주세요',
+                    prefixIcon: const Icon(Icons.search),
+                    filled: true,
+                    fillColor: Colors.white,
+                    contentPadding: const EdgeInsets.symmetric(vertical: 10),
+                    border: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(30),
+                      borderSide: BorderSide.none,
+                    ),
+                  ),
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 20),
+                child: ElevatedButton.icon(
+                  onPressed: _showAddWordDialog,
+                  icon: Icon(Icons.add),
+                  label: Text('단어 추가'),
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: Colors.white,
+                    foregroundColor: Colors.black87,
+                    elevation: 2,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(30),
+                    ),
+                  ),
+                ),
+              ),
+              SizedBox(height: 10),
+              Expanded(
+                child: ListView.builder(
+                  itemCount: wordList.length,
+                  itemBuilder: (context, index) {
+                    final word = wordList[index];
+                    return Container(
+                      margin: EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                      padding: EdgeInsets.all(12),
+                      decoration: BoxDecoration(
+                        color: word['isLearned'] ? Colors.green[200] : Colors.yellow[200],
+                        borderRadius: BorderRadius.circular(12),
+                        boxShadow: [
+                          BoxShadow(
+                            color: Colors.black12,
+                            blurRadius: 4,
+                            offset: Offset(2, 2),
+                          ),
+                        ],
+                      ),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Row(
+                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                            children: [
+                              Expanded(
+                                child: Text(
+                                  word['word'],
+                                  style: TextStyle(
+                                    fontSize: 18,
+                                    fontWeight: FontWeight.bold,
+                                  ),
+                                ),
+                              ),
+                              Row(
+                                children: [
+                                  Switch(
+                                    value: word['isLearned'],
+                                    onChanged: (val) {
+                                      setState(() {
+                                        word['isLearned'] = val;
+                                      });
+                                    },
+                                  ),
+                                  Column(
+                                    children: [
+                                      IconButton(
+                                        icon: Icon(Icons.volume_up),
+                                        onPressed: () {
+                                          // 발음 재생 처리 가능
+                                        },
+                                      ),
+                                      IconButton(
+                                        icon: Icon(Icons.delete_outline),
+                                        onPressed: () => _showDeleteDialog(index),
+                                      ),
+                                    ],
+                                  ),
+                                ],
+                              ),
+                            ],
+                          ),
+                          SizedBox(height: 8),
+                          Text(
+                            word['meaning'],
+                            style: TextStyle(fontSize: 16),
+                          ),
+                        ],
+                      ),
+                    );
+                  },
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/mobidic_flutter/lib/main.dart
+++ b/mobidic_flutter/lib/main.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
-import 'package:mobidic_flutter/login_UI.dart';
 
 import 'OX_Quiz.dart';
-import 'join_UI.dart';
+import 'MainPage.dart';
+import 'list.dart';
 
 void main() => runApp(MyApp());
 
@@ -15,8 +15,7 @@ class MyApp extends StatelessWidget {
       debugShowCheckedModeBanner: false,
       initialRoute: '/',
       routes: {
-        '/': (context) =>  LoginPage(),
-        '/signup': (context) => SignUpPage(),
+        '/': (context) =>  VocabularyScreen(),
         '/oxquiz': (context) => OxQuizPage(),
       },
     );

--- a/mobidic_flutter/lib/synonyms.dart
+++ b/mobidic_flutter/lib/synonyms.dart
@@ -1,0 +1,199 @@
+import 'package:flutter/material.dart';
+
+void main() {
+  runApp(const SynonymGameApp());
+}
+
+class SynonymGameApp extends StatelessWidget {
+  const SynonymGameApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: SynonymGameScreen(),
+      debugShowCheckedModeBanner: false,
+    );
+  }
+}
+
+class SynonymGameScreen extends StatefulWidget {
+  const SynonymGameScreen({super.key});
+
+  @override
+  State<SynonymGameScreen> createState() => _SynonymGameScreenState();
+}
+
+class _SynonymGameScreenState extends State<SynonymGameScreen> {
+  final List<Map<String, dynamic>> problems = [
+    {
+      'question': '눈',
+      'description': '하얗고 차가운 결정체, 눈이 내리다',
+      'options': ['snow', 'eye', 'class'],
+      'answers': ['snow', 'eye'],
+    },
+    {
+      'question': '밤',
+      'description': '밤하늘, 밤에 먹는 간식 또는 열매',
+      'options': ['chestnut', 'night', 'knight'],
+      'answers': ['chestnut', 'night'],
+    },
+  ];
+
+  int currentIndex = 0;
+  Set<String> selected = {};
+  bool showNext = false;
+
+  void _selectOption(String option) {
+    setState(() {
+      if (selected.contains(option)) {
+        selected.remove(option);
+      } else {
+        selected.add(option);
+      }
+
+      if (_isCorrect()) {
+        showNext = true;
+      } else {
+        showNext = false;
+      }
+    });
+  }
+
+  bool _isCorrect() {
+    final correctAnswers = problems[currentIndex]['answers'] as List<String>;
+    return selected.length == correctAnswers.length &&
+        selected.every((s) => correctAnswers.contains(s));
+  }
+
+  void _goToNext() {
+    setState(() {
+      currentIndex = (currentIndex + 1) % problems.length;
+      selected.clear();
+      showNext = false;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final problem = problems[currentIndex];
+
+    return Scaffold(
+      body: Container(
+        padding: const EdgeInsets.all(24.0),
+        width: double.infinity,
+        decoration: const BoxDecoration(
+          gradient: LinearGradient(
+            colors: [Color(0xFFb3e5fc), Color(0xFF81d4fa)],
+            begin: Alignment.topCenter,
+            end: Alignment.bottomCenter,
+          ),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const SizedBox(height: 40),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Row(
+                  children: const [
+                    Icon(Icons.arrow_back, size: 28),
+                    SizedBox(width: 8),
+                    Text('유의어 맞추기',
+                        style: TextStyle(
+                            fontSize: 20, fontWeight: FontWeight.bold)),
+                  ],
+                ),
+                const Icon(Icons.home, size: 28),
+              ],
+            ),
+            const SizedBox(height: 30),
+
+            // 중앙 제시어 박스
+            Center(
+              child: Container(
+                padding: const EdgeInsets.symmetric(
+                    vertical: 20, horizontal: 40),
+                decoration: BoxDecoration(
+                  color: Colors.white,
+                  borderRadius: BorderRadius.circular(16),
+                  boxShadow: [
+                    BoxShadow(
+                      color: Colors.black26,
+                      blurRadius: 4,
+                      offset: Offset(2, 2),
+                    ),
+                  ],
+                ),
+                child: Text(
+                  '제시어: ${problem['question']}',
+                  style: const TextStyle(
+                      fontSize: 24, fontWeight: FontWeight.bold),
+                ),
+              ),
+            ),
+            const SizedBox(height: 20),
+
+            // 설명 중앙 정렬
+            Center(
+              child: Text(
+                problem['description'],
+                style: const TextStyle(fontSize: 18),
+              ),
+            ),
+            const SizedBox(height: 30),
+
+            // 보기 버튼 중앙 정렬
+            Center(
+              child: Column(
+                children: List.generate(
+                    (problem['options'] as List).length, (index) {
+                  String option = problem['options'][index];
+                  bool isSelected = selected.contains(option);
+                  Color bgColor = isSelected
+                      ? (problem['answers'].contains(option)
+                      ? Colors.green
+                      : Colors.grey)
+                      : Colors.grey.shade400;
+
+                  return Container(
+                    margin: const EdgeInsets.only(bottom: 12),
+                    child: ElevatedButton(
+                      onPressed: () => _selectOption(option),
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: bgColor,
+                        foregroundColor: Colors.white,
+                        padding: const EdgeInsets.symmetric(
+                            vertical: 14, horizontal: 30),
+                        shape: const StadiumBorder(),
+                      ),
+                      child: Text(option,
+                          style: const TextStyle(fontSize: 18)),
+                    ),
+                  );
+                }),
+              ),
+            ),
+
+            const SizedBox(height: 20),
+
+            if (showNext)
+              Center(
+                child: ElevatedButton(
+                  onPressed: _goToNext,
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: Colors.white,
+                    foregroundColor: Colors.black,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(20),
+                    ),
+                  ),
+                  child: const Text('다음 문제'),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
[feat: 플래시카드 ui구현]
- 눈 아이콘 활성/비활성화에 따라 단어 가리기/보여주기 기능 구현
- 하단에 화살표 누르면 다음 단어 보여줌

[feat: 유의어 맞추기 ui 구현]
- 제시어(뜻)이 나오면 문제 항목 중 유의어 2개를 맞추어야 다음 문제로 넘어간다.

[feat: 단어 목록 ui 구현]
- 단어 목록 추가/삭제 기능
- 단어 추가 시 영단어, 뜻 입력 기능
- 스위치 누르면 학습 완료/필요 체크

[feat: 단어장 목록 ui 구현]
- 단어장 목록 추가/삭제 기능
- 퀴즈 버튼 누르면 퀴즈 종류 나옴

[fix: 단어장 목록(메인페이지), 단어 목록 화면 라우터 추가]
- 루트 수정 필요